### PR TITLE
Enable basic PC build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# Select build platform (gba by default)
+PLATFORM    ?= gba
+
+# If building for PC, hand off to the dedicated PC makefile and stop
+ifeq ($(PLATFORM),pc)
+include platform/pc/Makefile.pc
+else
+
 # GBA rom header
 TITLE       := POKEMON EMER
 GAME_CODE   := BPEE
@@ -5,10 +13,6 @@ MAKER_CODE  := 01
 REVISION    := 0
 MODERN      ?= 0
 KEEP_TEMPS  ?= 0
-PLATFORM    ?= gba
-ifeq ($(PLATFORM),pc)
-  CFLAGS += -DPLATFORM_PC
-endif
 
 # `File name`.gba ('_modern' will be appended to the modern builds)
 FILE_NAME := pokeemerald
@@ -409,4 +413,6 @@ $(ROM): $(ELF)
 
 # Symbol file (`make syms`)
 $(SYM): $(ELF)
-	$(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+        $(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+
+endif # PLATFORM

--- a/platform/pc/Makefile.pc
+++ b/platform/pc/Makefile.pc
@@ -1,0 +1,27 @@
+.RECIPEPREFIX := >
+
+# PC build rules
+CC := cc
+CFLAGS ?= -O2
+CFLAGS += -DPLATFORM_PC -Iinclude
+
+PC_SRCS := src/main.c \
+           platform/pc/platform.c \
+           platform/pc/main.c \
+           platform/pc/video.c \
+           platform/pc/audio.c \
+           platform/pc/input.c \
+           platform/pc/timer.c \
+           platform/pc/fs.c
+
+PC_OBJS := $(patsubst %.c,build/pc/%.o,$(PC_SRCS))
+
+all: $(PC_OBJS)
+
+build/pc/%.o: %.c
+>mkdir -p $(dir $@)
+>$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+>rm -rf build/pc
+


### PR DESCRIPTION
## Summary
- Delegate PC builds to a dedicated Makefile
- Add simple `platform/pc/Makefile.pc` compiling core platform stubs and main

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`


------
https://chatgpt.com/codex/tasks/task_e_6896313ebef483248bc18848874f0782