### PR TITLE
Add SDL-backed input and timing to PC platform

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -9,3 +9,4 @@
 - Reordered `global.h` includes and expanded PC GBA shims to expose basic types, registers, and BIOS call declarations, resolving `u8` and other undefined identifier errors during PC builds.
 - Introduced lightweight PC implementations of DMA/CPU helper macros and forward declarations so desktop compilers no longer warn about missing prototypes or pointer truncation when building core sources.
 - Added C replacements for BIOS syscalls in `platform/pc/syscalls.c`, covering interrupt waits, memory operations, and LZ77 decompression; wired into the PC build to remove dependence on assembly stubs.
+- Implemented SDL-backed input polling and 60 FPS timer, integrated SDL initialization/shutdown in the platform layer, added SDL2 build flags and DPAD constants, and adjusted strings header to coexist with system includes.

--- a/include/strings.h
+++ b/include/strings.h
@@ -1,6 +1,9 @@
 #ifndef GUARD_STRINGS_H
 #define GUARD_STRINGS_H
 
+#include "gba/types.h"
+#include_next <strings.h>
+
 // Placeholders
 extern const u8 gText_ExpandedPlaceholder_Empty[];
 extern const u8 gText_ExpandedPlaceholder_Kun[];

--- a/platform/pc/Makefile.pc
+++ b/platform/pc/Makefile.pc
@@ -3,7 +3,8 @@
 # PC build rules
 CC := cc
 CFLAGS ?= -O2
-CFLAGS += -DPLATFORM_PC -Iinclude
+SDL_CFLAGS := $(shell sdl2-config --cflags)
+CFLAGS += -DPLATFORM_PC -Iinclude $(SDL_CFLAGS)
 
 PC_SRCS := src/main.c \
            platform/pc/platform.c \

--- a/platform/pc/gba/io_reg.h
+++ b/platform/pc/gba/io_reg.h
@@ -62,5 +62,10 @@
 #define D_DOWN          0x0080
 #define R_BUTTON        0x0100
 #define L_BUTTON        0x0200
+#define DPAD_RIGHT      D_RIGHT
+#define DPAD_LEFT       D_LEFT
+#define DPAD_UP         D_UP
+#define DPAD_DOWN       D_DOWN
+#define DPAD_ANY        (DPAD_RIGHT | DPAD_LEFT | DPAD_UP | DPAD_DOWN)
 
 #endif // PC_GBA_IO_REG_H

--- a/platform/pc/input.c
+++ b/platform/pc/input.c
@@ -1,13 +1,51 @@
 #include "input.h"
+#include <SDL.h>
+#include "gba/io_reg.h"
 
 static u16 sKeyState;
+static bool sQuit;
+
+static void SetKey(u16 mask, bool down)
+{
+    if (down)
+        sKeyState |= mask;
+    else
+        sKeyState &= ~mask;
+}
 
 void InputPoll(void)
 {
-    sKeyState = 0;
+    SDL_Event e;
+    while (SDL_PollEvent(&e))
+    {
+        if (e.type == SDL_QUIT)
+            sQuit = true;
+        else if (e.type == SDL_KEYDOWN || e.type == SDL_KEYUP)
+        {
+            bool down = (e.type == SDL_KEYDOWN);
+            switch (e.key.keysym.scancode)
+            {
+            case SDL_SCANCODE_Z:        SetKey(A_BUTTON, down); break;
+            case SDL_SCANCODE_X:        SetKey(B_BUTTON, down); break;
+            case SDL_SCANCODE_BACKSPACE:SetKey(SELECT_BUTTON, down); break;
+            case SDL_SCANCODE_RETURN:   SetKey(START_BUTTON, down); break;
+            case SDL_SCANCODE_RIGHT:    SetKey(DPAD_RIGHT, down); break;
+            case SDL_SCANCODE_LEFT:     SetKey(DPAD_LEFT, down); break;
+            case SDL_SCANCODE_UP:       SetKey(DPAD_UP, down); break;
+            case SDL_SCANCODE_DOWN:     SetKey(DPAD_DOWN, down); break;
+            case SDL_SCANCODE_A:        SetKey(L_BUTTON, down); break;
+            case SDL_SCANCODE_S:        SetKey(R_BUTTON, down); break;
+            }
+        }
+    }
 }
 
 u16 InputGetKeys(void)
 {
     return sKeyState;
+}
+
+bool InputShouldQuit(void)
+{
+    return sQuit;
 }

--- a/platform/pc/input.h
+++ b/platform/pc/input.h
@@ -6,5 +6,6 @@
 
 void InputPoll(void);
 u16 InputGetKeys(void);
+bool InputShouldQuit(void);
 
 #endif // PLATFORM_PC_INPUT_H

--- a/platform/pc/platform.c
+++ b/platform/pc/platform.c
@@ -4,17 +4,25 @@
 #include "input.h"
 #include "timer.h"
 #include "fs.h"
+#include <SDL.h>
 
 bool PlatformInit(void)
 {
-    return VideoInit() && AudioInit() && TimerInit();
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_TIMER) < 0)
+        return false;
+    if (!VideoInit() || !AudioInit() || !TimerInit())
+    {
+        SDL_Quit();
+        return false;
+    }
+    return true;
 }
 
 bool PlatformRunFrame(void)
 {
     InputPoll();
     VideoUpdate();
-    return true;
+    return !InputShouldQuit();
 }
 
 void PlatformShutdown(void)
@@ -22,6 +30,7 @@ void PlatformShutdown(void)
     AudioShutdown();
     VideoShutdown();
     TimerShutdown();
+    SDL_Quit();
 }
 
 void PlatformSetBackdropColor(u16 color)

--- a/platform/pc/timer.c
+++ b/platform/pc/timer.c
@@ -1,12 +1,23 @@
 #include "timer.h"
+#include <SDL.h>
+#include "gba/types.h"
+
+static u32 sFrameStart;
 
 bool TimerInit(void)
 {
+    sFrameStart = SDL_GetTicks();
     return true;
 }
 
 void TimerWaitVBlank(void)
 {
+    u32 now = SDL_GetTicks();
+    u32 elapsed = now - sFrameStart;
+    const u32 frameMs = 1000 / 60;
+    if (elapsed < frameMs)
+        SDL_Delay(frameMs - elapsed);
+    sFrameStart = SDL_GetTicks();
 }
 
 void TimerShutdown(void)


### PR DESCRIPTION
## Summary
- Add SDL2 include flags for PC build
- Implement SDL input polling with keyboard mapping and quit detection
- Add SDL-based frame timer and initialize SDL subsystems in platform layer
- Provide DPAD macros and adjust strings header to include system definitions

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`


------
https://chatgpt.com/codex/tasks/task_e_689639f276e083249374235a3ac78e41