### PR TITLE
Add executable build test to AGENTS instructions

### DIFF
--- a/AGENTS_PROJECT.md
+++ b/AGENTS_PROJECT.md
@@ -19,4 +19,8 @@ and:
 
 'make PLATFORM=pc'
 
+and:
+
+`cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o /tmp/pokeemerald.exe`
+
 If any of them fail, investigate the issue and implement a full fix without compromising any of the original game's features. Rerun tests afterwards to verify your fix worked. If it didn't, reinvestigate why and implement the proper solution.


### PR DESCRIPTION
## Summary
- Document a new test that attempts to link the PC build objects into a `pokeemerald.exe` executable

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o /tmp/pokeemerald.exe` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_68964f6ac5b08324a57e73cb47282623