### PR TITLE
Add stubs for PC build linkage

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -13,3 +13,4 @@
 - Added an SDL-based video subsystem that opens a 240×160 window, manages an ARGB framebuffer, applies backdrop colors, and blits frames each iteration.
 - Implemented SDL audio backend that feeds m4a’s PCM buffer to the host device, added `SOUND_INFO_PTR` shim, and wrapped hardware-specific portions of `m4a.c` for safe desktop builds.
 - Included 'gba/types.h' in custom malloc header to prevent system <malloc.h> collisions during PC builds.
+- Added PC Makefile support for m4a tables, introduced stubbed GameLoop and m4a engine placeholders so the desktop build links successfully; full audio and game logic remain TODO.

--- a/platform/pc/Makefile.pc
+++ b/platform/pc/Makefile.pc
@@ -7,8 +7,7 @@ SDL_CFLAGS := $(shell sdl2-config --cflags)
 # Use -iquote so our headers don't override system ones like <malloc.h>
 CFLAGS += -DPLATFORM_PC -iquote include $(SDL_CFLAGS)
 
-PC_SRCS := src/main.c \
-           platform/pc/platform.c \
+PC_SRCS := platform/pc/platform.c \
            platform/pc/main.c \
            platform/pc/video.c \
            platform/pc/audio.c \
@@ -16,7 +15,10 @@ PC_SRCS := src/main.c \
            platform/pc/timer.c \
            platform/pc/fs.c \
            platform/pc/syscalls.c \
-           src/m4a.c
+           platform/pc/game_loop_stub.c \
+           platform/pc/m4a_stub.c \
+           src/m4a.c \
+           src/m4a_tables.c
 
 PC_OBJS := $(patsubst %.c,build/pc/%.o,$(PC_SRCS))
 

--- a/platform/pc/game_loop_stub.c
+++ b/platform/pc/game_loop_stub.c
@@ -1,0 +1,7 @@
+#include "global.h"
+#include "main.h"
+
+bool32 GameLoop(void)
+{
+    return FALSE;
+}

--- a/platform/pc/m4a_stub.c
+++ b/platform/pc/m4a_stub.c
@@ -1,0 +1,47 @@
+#include "global.h"
+#include "gba/m4a_internal.h"
+
+// Minimal stubs for the m4a sound engine to satisfy the linker on PC builds.
+// These perform no audio logic.
+
+// Tables expected by m4a.c
+const struct Song gSongTable[] = { {0} };
+const struct MusicPlayer gMPlayTable[] = { {0} };
+const struct ToneData voicegroup_dummy = {0};
+
+// Core engine routines
+void MPlayMain(struct MusicPlayerInfo *mplayInfo) { (void)mplayInfo; }
+void MPlayJumpTableCopy(MPlayFunc *table) { (void)table; }
+void TrackStop(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) { (void)mplayInfo; (void)track; }
+void SoundMain(void) {}
+char SoundMainRAM[1];
+void RealClearChain(void *x) { (void)x; }
+void SoundMainBTM(void) {}
+
+// Utility helpers
+u32 umul3232H32(u32 a, u32 b) { (void)a; (void)b; return 0; }
+
+// Player command handlers
+#define STUB_PLY(name, ...) void name(__VA_ARGS__) { (void)0; }
+
+STUB_PLY(ply_fine, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_goto, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_patt, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_pend, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_rept, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_prio, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_tempo, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_keysh, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_voice, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_vol, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_pan, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_bend, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_bendr, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_lfos, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_lfodl, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_mod, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_modt, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_tune, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_port, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_endtie, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);
+STUB_PLY(ply_note, u32 note_cmd, struct MusicPlayerInfo *a, struct MusicPlayerTrack *b);


### PR DESCRIPTION
## Summary
- Include m4a tables in PC build and add stubbed GameLoop for minimal desktop executable
- Provide no-op m4a engine placeholders so the SDL PC build links

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o /tmp/pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896528fd73083248592b5bc24609105