### PR TITLE
Fix Makefile SYM rule indentation for PC build

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -14,3 +14,4 @@
 - Implemented SDL audio backend that feeds m4a’s PCM buffer to the host device, added `SOUND_INFO_PTR` shim, and wrapped hardware-specific portions of `m4a.c` for safe desktop builds.
 - Included 'gba/types.h' in custom malloc header to prevent system <malloc.h> collisions during PC builds.
 - Added PC Makefile support for m4a tables, introduced stubbed GameLoop and m4a engine placeholders so the desktop build links successfully; full audio and game logic remain TODO.
+- Corrected SYM rule indentation in Makefile, restored placeholder map_groups.h, installed SDL2 dependencies, and verified PC build links to /tmp/pokeemerald.exe.

--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,6 @@ $(ROM): $(ELF)
 
 # Symbol file (`make syms`)
 $(SYM): $(ELF)
-        $(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+	$(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$\$/\1 \2 \3 \4/g' > $@
 
 endif # PLATFORM


### PR DESCRIPTION
## Summary
- fix SYM rule in Makefile to use a proper tab and keep redirection on the same line
- document the fix and SDL2 dependency setup in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o /tmp/pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_689666ef38b88324bf1cf9d7cc7f36bf