### PR TITLE
Link PC build to root executable

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -15,3 +15,4 @@
 - Included 'gba/types.h' in custom malloc header to prevent system <malloc.h> collisions during PC builds.
 - Added PC Makefile support for m4a tables, introduced stubbed GameLoop and m4a engine placeholders so the desktop build links successfully; full audio and game logic remain TODO.
 - Corrected SYM rule indentation in Makefile, restored placeholder map_groups.h, installed SDL2 dependencies, and verified PC build links to /tmp/pokeemerald.exe.
+- Updated PC make rules to link all objects and emit `pokeemerald.exe` in the repository root, adjusting tests accordingly.

--- a/AGENTS_PROJECT.md
+++ b/AGENTS_PROJECT.md
@@ -21,6 +21,6 @@ and:
 
 and:
 
-`cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o /tmp/pokeemerald.exe`
+`cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`
 
 If any of them fail, investigate the issue and implement a full fix without compromising any of the original game's features. Rerun tests afterwards to verify your fix worked. If it didn't, reinvestigate why and implement the proper solution.

--- a/platform/pc/Makefile.pc
+++ b/platform/pc/Makefile.pc
@@ -4,8 +4,10 @@
 CC := cc
 CFLAGS ?= -O2
 SDL_CFLAGS := $(shell sdl2-config --cflags)
+SDL_LIBS := $(shell sdl2-config --libs)
 # Use -iquote so our headers don't override system ones like <malloc.h>
 CFLAGS += -DPLATFORM_PC -iquote include $(SDL_CFLAGS)
+LDFLAGS := $(SDL_LIBS) -lSDL2_image -lSDL2_mixer
 
 PC_SRCS := platform/pc/platform.c \
            platform/pc/main.c \
@@ -22,12 +24,17 @@ PC_SRCS := platform/pc/platform.c \
 
 PC_OBJS := $(patsubst %.c,build/pc/%.o,$(PC_SRCS))
 
-all: $(PC_OBJS)
+OUTPUT := pokeemerald.exe
+
+all: $(OUTPUT)
+
+$(OUTPUT): $(PC_OBJS)
+>$(CC) $(PC_OBJS) $(LDFLAGS) -o $@
 
 build/pc/%.o: %.c
 >mkdir -p $(dir $@)
 >$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
->rm -rf build/pc
+>rm -rf build/pc $(OUTPUT)
 


### PR DESCRIPTION
## Summary
- Link all PC object files into a `pokeemerald.exe` in the repo root.
- Update project instructions to expect the executable in the root directory.
- Log the new PC build step in AGENTS_LOG.

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`

------
https://chatgpt.com/codex/tasks/task_e_6896698f0754832484f526ba12aa9f6e