### PR TITLE
Add basic asset file loader for PC port

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -16,3 +16,4 @@
 - Added PC Makefile support for m4a tables, introduced stubbed GameLoop and m4a engine placeholders so the desktop build links successfully; full audio and game logic remain TODO.
 - Corrected SYM rule indentation in Makefile, restored placeholder map_groups.h, installed SDL2 dependencies, and verified PC build links to /tmp/pokeemerald.exe.
 - Updated PC make rules to link all objects and emit `pokeemerald.exe` in the repository root, adjusting tests accordingly.
+- Began runtime asset loading by adding `platform/pc/assets.c` and header with file-loading helper, integrated into the PC build; caching and PNG decoding remain TODO.

--- a/platform/pc/Makefile.pc
+++ b/platform/pc/Makefile.pc
@@ -16,6 +16,7 @@ PC_SRCS := platform/pc/platform.c \
            platform/pc/input.c \
            platform/pc/timer.c \
            platform/pc/fs.c \
+           platform/pc/assets.c \
            platform/pc/syscalls.c \
            platform/pc/game_loop_stub.c \
            platform/pc/m4a_stub.c \

--- a/platform/pc/assets.c
+++ b/platform/pc/assets.c
@@ -1,0 +1,44 @@
+#include "assets.h"
+#include <SDL.h>
+#include <stdlib.h>
+
+void *AssetsLoadFile(const char *path, size_t *size)
+{
+    if (size)
+        *size = 0;
+
+    SDL_RWops *rw = SDL_RWFromFile(path, "rb");
+    if (!rw)
+        return NULL;
+
+    Sint64 len = SDL_RWsize(rw);
+    if (len <= 0)
+    {
+        SDL_RWclose(rw);
+        return NULL;
+    }
+
+    void *buffer = malloc((size_t)len);
+    if (!buffer)
+    {
+        SDL_RWclose(rw);
+        return NULL;
+    }
+
+    if (SDL_RWread(rw, buffer, 1, (size_t)len) != (size_t)len)
+    {
+        free(buffer);
+        SDL_RWclose(rw);
+        return NULL;
+    }
+
+    SDL_RWclose(rw);
+    if (size)
+        *size = (size_t)len;
+    return buffer;
+}
+
+void AssetsFreeFile(void *buffer)
+{
+    free(buffer);
+}

--- a/platform/pc/assets.h
+++ b/platform/pc/assets.h
@@ -1,0 +1,9 @@
+#ifndef PLATFORM_PC_ASSETS_H
+#define PLATFORM_PC_ASSETS_H
+
+#include <stddef.h>
+
+void *AssetsLoadFile(const char *path, size_t *size);
+void AssetsFreeFile(void *buffer);
+
+#endif // PLATFORM_PC_ASSETS_H


### PR DESCRIPTION
## Summary
- Add initial runtime asset loader for PC platform
- Integrate assets module into PC build system
- Log runtime asset loader progress in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68966c5d26e48324bfc0c4e1a53b4154