### PR TITLE
Implement cached asset loader with PNG support

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -17,3 +17,4 @@
 - Corrected SYM rule indentation in Makefile, restored placeholder map_groups.h, installed SDL2 dependencies, and verified PC build links to /tmp/pokeemerald.exe.
 - Updated PC make rules to link all objects and emit `pokeemerald.exe` in the repository root, adjusting tests accordingly.
 - Began runtime asset loading by adding `platform/pc/assets.c` and header with file-loading helper, integrated into the PC build; caching and PNG decoding remain TODO.
+- Added basic asset caching and PNG decoding with SDL_image, exposing `AssetsLoadPNG` and initializing SDL_image in the platform layer to progress runtime asset loading.

--- a/platform/pc/assets.c
+++ b/platform/pc/assets.c
@@ -1,11 +1,42 @@
 #include "assets.h"
+#include <SDL_image.h>
 #include <SDL.h>
 #include <stdlib.h>
+#include <string.h>
+
+typedef struct FileCacheEntry
+{
+    char *path;
+    void *data;
+    size_t size;
+    struct FileCacheEntry *next;
+} FileCacheEntry;
+
+typedef struct PngCacheEntry
+{
+    char *path;
+    SDL_Surface *surface;
+    struct PngCacheEntry *next;
+} PngCacheEntry;
+
+static FileCacheEntry *sFileCache;
+static PngCacheEntry *sPngCache;
 
 void *AssetsLoadFile(const char *path, size_t *size)
 {
     if (size)
         *size = 0;
+
+    // Check cache first
+    for (FileCacheEntry *e = sFileCache; e != NULL; e = e->next)
+    {
+        if (strcmp(e->path, path) == 0)
+        {
+            if (size)
+                *size = e->size;
+            return e->data;
+        }
+    }
 
     SDL_RWops *rw = SDL_RWFromFile(path, "rb");
     if (!rw)
@@ -33,12 +64,58 @@ void *AssetsLoadFile(const char *path, size_t *size)
     }
 
     SDL_RWclose(rw);
+
+    FileCacheEntry *entry = malloc(sizeof(*entry));
+    if (!entry)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    entry->path = SDL_strdup(path);
+    entry->data = buffer;
+    entry->size = (size_t)len;
+    entry->next = sFileCache;
+    sFileCache = entry;
+
     if (size)
-        *size = (size_t)len;
-    return buffer;
+        *size = entry->size;
+    return entry->data;
 }
 
 void AssetsFreeFile(void *buffer)
 {
-    free(buffer);
+    (void)buffer;
+}
+
+SDL_Surface *AssetsLoadPNG(const char *path)
+{
+    for (PngCacheEntry *e = sPngCache; e != NULL; e = e->next)
+    {
+        if (strcmp(e->path, path) == 0)
+            return e->surface;
+    }
+
+    SDL_Surface *surf = IMG_Load(path);
+    if (!surf)
+        return NULL;
+
+    SDL_Surface *converted = SDL_ConvertSurfaceFormat(surf, SDL_PIXELFORMAT_ARGB8888, 0);
+    SDL_FreeSurface(surf);
+    if (!converted)
+        return NULL;
+
+    PngCacheEntry *entry = malloc(sizeof(*entry));
+    if (!entry)
+    {
+        SDL_FreeSurface(converted);
+        return NULL;
+    }
+
+    entry->path = SDL_strdup(path);
+    entry->surface = converted;
+    entry->next = sPngCache;
+    sPngCache = entry;
+
+    return converted;
 }

--- a/platform/pc/assets.h
+++ b/platform/pc/assets.h
@@ -2,8 +2,19 @@
 #define PLATFORM_PC_ASSETS_H
 
 #include <stddef.h>
+#include <SDL.h>
 
+// Returns a pointer to the file contents. Subsequent calls with the same path
+// reuse a cached copy to avoid redundant disk access. The returned buffer
+// persists for the lifetime of the program and should not be freed directly.
 void *AssetsLoadFile(const char *path, size_t *size);
+
+// Convenience wrapper that decodes a PNG file into an ARGB8888 surface. The
+// surface is cached by path and is owned by the asset system.
+SDL_Surface *AssetsLoadPNG(const char *path);
+
+// No-op placeholder provided for API compatibility with earlier loaders. The
+// cache retains loaded resources for the program lifetime.
 void AssetsFreeFile(void *buffer);
 
 #endif // PLATFORM_PC_ASSETS_H

--- a/platform/pc/platform.c
+++ b/platform/pc/platform.c
@@ -5,13 +5,22 @@
 #include "timer.h"
 #include "fs.h"
 #include <SDL.h>
+#include <SDL_image.h>
 
 bool PlatformInit(void)
 {
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_TIMER) < 0)
         return false;
+
+    if (!(IMG_Init(IMG_INIT_PNG) & IMG_INIT_PNG))
+    {
+        SDL_Quit();
+        return false;
+    }
+
     if (!VideoInit() || !AudioInit() || !TimerInit())
     {
+        IMG_Quit();
         SDL_Quit();
         return false;
     }
@@ -30,6 +39,7 @@ void PlatformShutdown(void)
     AudioShutdown();
     VideoShutdown();
     TimerShutdown();
+    IMG_Quit();
     SDL_Quit();
 }
 


### PR DESCRIPTION
## Summary
- Cache loaded files and PNG surfaces to avoid redundant disk I/O
- Add `AssetsLoadPNG` using SDL_image and initialize SDL_image in platform layer
- Document asset system progress in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68966f7e5e448324997cab587ece640d