### PR TITLE
pc: add palette constants and replace first incbin

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -18,3 +18,4 @@
 - Updated PC make rules to link all objects and emit `pokeemerald.exe` in the repository root, adjusting tests accordingly.
 - Began runtime asset loading by adding `platform/pc/assets.c` and header with file-loading helper, integrated into the PC build; caching and PNG decoding remain TODO.
 - Added basic asset caching and PNG decoding with SDL_image, exposing `AssetsLoadPNG` and initializing SDL_image in the platform layer to progress runtime asset loading.
+- Filled out the PC GBA shim with display and palette constants and replaced one `INCBIN` usage with a lazy loader in `util.c`, beginning actual runtime asset substitution.

--- a/include/util.h
+++ b/include/util.h
@@ -3,7 +3,12 @@
 
 #include "sprite.h"
 
+#ifdef PLATFORM_PC
+const u8 *LoadMiscBlankGfx(void);
+#define gMiscBlank_Gfx (LoadMiscBlankGfx())
+#else
 extern const u8 gMiscBlank_Gfx[]; // unused in Emerald
+#endif
 extern const u32 gBitTable[];
 
 u8 CreateInvisibleSpriteWithCallback(void (*callback)(struct Sprite *));

--- a/platform/pc/gba/defines.h
+++ b/platform/pc/gba/defines.h
@@ -21,4 +21,17 @@ struct SoundInfo;
 extern struct SoundInfo *gSoundInfoPtr;
 #define SOUND_INFO_PTR gSoundInfoPtr
 
+// Basic VRAM/Palette constants used by core code. Values are placeholders
+// sufficient for desktop builds and do not map to real hardware addresses.
+#define PLTT          0
+#define BG_PLTT       PLTT
+#define BG_PLTT_SIZE  0x200
+#define OBJ_PLTT      (PLTT + BG_PLTT_SIZE)
+#define OBJ_PLTT_SIZE 0x200
+#define PLTT_SIZE     (BG_PLTT_SIZE + OBJ_PLTT_SIZE)
+#define PLTT_SIZEOF(n) ((n) * sizeof(u16))
+
+#define DISPLAY_WIDTH  240
+#define DISPLAY_HEIGHT 160
+
 #endif // PC_GBA_DEFINES_H

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,9 @@
 #include "sprite.h"
 #include "palette.h"
 #include "constants/rgb.h"
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
 
 const u32 gBitTable[] =
 {
@@ -114,7 +117,18 @@ static const u16 sCrc16Table[] =
     0x7BC7, 0x6A4E, 0x58D5, 0x495C, 0x3DE3, 0x2C6A, 0x1EF1, 0x0F78,
 };
 
+#ifdef PLATFORM_PC
+static const u8 *sMiscBlankGfx;
+
+const u8 *LoadMiscBlankGfx(void)
+{
+    if (!sMiscBlankGfx)
+        sMiscBlankGfx = AssetsLoadFile("graphics/interface/blank.4bpp", NULL);
+    return sMiscBlankGfx;
+}
+#else
 const u8 gMiscBlank_Gfx[] = INCBIN_U8("graphics/interface/blank.4bpp");
+#endif
 
 u8 CreateInvisibleSpriteWithCallback(void (*callback)(struct Sprite *))
 {


### PR DESCRIPTION
## Summary
- extend PC GBA shim with palette and display constants
- load `gMiscBlank_Gfx` from disk on demand instead of using INCBIN
- expose helper macro so callers transparently access runtime asset

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68967123e0188324b4691bff62298236