### PR TITLE
Add 4bpp tile loader

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -20,3 +20,4 @@
 - Added basic asset caching and PNG decoding with SDL_image, exposing `AssetsLoadPNG` and initializing SDL_image in the platform layer to progress runtime asset loading.
 - Filled out the PC GBA shim with display and palette constants and replaced one `INCBIN` usage with a lazy loader in `util.c`, beginning actual runtime asset substitution.
 - Implemented JASC-PAL palette parsing and caching in the PC asset loader, switched blank interface assets to load PNG/palette at runtime, and updated contest utilities to assign these resources dynamically.
+- Added PNG to 4bpp tile conversion with caching in the PC asset loader and updated `LoadMiscBlankGfx` to use runtime-loaded tiles.

--- a/platform/pc/assets.h
+++ b/platform/pc/assets.h
@@ -18,6 +18,10 @@ SDL_Surface *AssetsLoadPNG(const char *path);
 // The returned buffer is cached and owned by the asset system.
 u16 *AssetsLoadPal(const char *path, size_t *size);
 
+// Load a paletted PNG and convert it to 4bpp tile data using the given
+// palette. The returned buffer is cached and owned by the asset system.
+u8 *AssetsLoad4bpp(const char *pngPath, const char *palPath, size_t *size);
+
 // No-op placeholder provided for API compatibility with earlier loaders. The
 // cache retains loaded resources for the program lifetime.
 void AssetsFreeFile(void *buffer);

--- a/src/util.c
+++ b/src/util.c
@@ -125,11 +125,7 @@ static const u16 *sMiscBlankPal;
 const u8 *LoadMiscBlankGfx(void)
 {
     if (!sMiscBlankGfx)
-    {
-        SDL_Surface *surf = AssetsLoadPNG("graphics/interface/blank.png");
-        if (surf)
-            sMiscBlankGfx = calloc(1, 0x20); // 8x8 tile of zeros
-    }
+        sMiscBlankGfx = AssetsLoad4bpp("graphics/interface/blank.png", "graphics/interface/blank.pal", NULL);
     return sMiscBlankGfx;
 }
 


### PR DESCRIPTION
## Summary
- extend PC asset loader with cached PNG-to-4bpp tile conversion
- use new loader for blank interface graphics
- log progress in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_689677d0b840832482ee78a996380c38