### PR TITLE
Load message box assets at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -22,3 +22,4 @@
 - Implemented JASC-PAL palette parsing and caching in the PC asset loader, switched blank interface assets to load PNG/palette at runtime, and updated contest utilities to assign these resources dynamically.
 - Added PNG to 4bpp tile conversion with caching in the PC asset loader and updated `LoadMiscBlankGfx` to use runtime-loaded tiles.
 - Extracted palettes from PNGs in the asset loader and switched text window frames and palettes to load at runtime, removing INCBIN dependencies for the PC build.
+- Replaced message box graphics and palette with PNG-based runtime loading, removed corresponding INCBIN data, and extended PC GBA shims with tile and palette size macros so text windows compile on desktop.

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -2,8 +2,10 @@
 #define GUARD_GRAPHICS_H
 
 // overworld
+#ifndef PLATFORM_PC
 extern const u8 gMessageBox_Gfx[];
 extern const u16 gMessageBox_Pal[];
+#endif
 
 // pokeballs
 extern const u32 gBallGfx_Poke[];

--- a/platform/pc/gba/defines.h
+++ b/platform/pc/gba/defines.h
@@ -31,6 +31,12 @@ extern struct SoundInfo *gSoundInfoPtr;
 #define PLTT_SIZE     (BG_PLTT_SIZE + OBJ_PLTT_SIZE)
 #define PLTT_SIZEOF(n) ((n) * sizeof(u16))
 
+#define TILE_SIZE(n) ((n) * 8)
+#define TILE_SIZE_4BPP TILE_SIZE(4)
+#define TILE_OFFSET_4BPP(n) ((n) * TILE_SIZE_4BPP)
+#define PLTT_SIZE_4BPP PLTT_SIZEOF(16)
+#define PLTT_OFFSET_4BPP(n) ((n) * PLTT_SIZE_4BPP)
+
 #define DISPLAY_WIDTH  240
 #define DISPLAY_HEIGHT 160
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1469,8 +1469,10 @@ const u16 gTradeUnused_Tilemap[] = INCBIN_U16("graphics/trade/unused.bin");
 const u16 gTradeMenu_Tilemap[] = INCBIN_U16("graphics/trade/menu.bin");
 const u16 gTradeMenuMonBox_Tilemap[] = INCBIN_U16("graphics/trade/menu_mon_box.bin");
 
+#ifndef PLATFORM_PC
 const u16 gMessageBox_Pal[] = INCBIN_U16("graphics/text_window/message_box.gbapal");
 const u8 gMessageBox_Gfx[] = INCBIN_U8("graphics/text_window/message_box.4bpp");
+#endif
 
 const u32 gWallpaperIcon_Cross[] = INCBIN_U32("graphics/pokemon_storage/wallpapers/icons/cross.4bpp.lz");
 const u32 gWallpaperIcon_Bolt[] = INCBIN_U32("graphics/pokemon_storage/wallpapers/icons/bolt.4bpp.lz");

--- a/src/text_window.c
+++ b/src/text_window.c
@@ -162,8 +162,14 @@ const struct TilesPal *GetWindowFrameTilesPal(u8 id)
 
 void LoadMessageBoxGfx(u8 windowId, u16 destOffset, u8 palOffset)
 {
+#ifdef PLATFORM_PC
+    const u8 *tiles = AssetsLoad4bpp("graphics/text_window/message_box.png", NULL, NULL);
+    LoadBgTiles(GetWindowAttribute(windowId, WINDOW_BG), tiles, 0x1C0, destOffset);
+    LoadPalette(GetOverworldTextboxPalettePtr(), palOffset, PLTT_SIZE_4BPP);
+#else
     LoadBgTiles(GetWindowAttribute(windowId, WINDOW_BG), gMessageBox_Gfx, 0x1C0, destOffset);
     LoadPalette(GetOverworldTextboxPalettePtr(), palOffset, PLTT_SIZE_4BPP);
+#endif
 }
 
 void LoadUserWindowBorderGfx_(u8 windowId, u16 destOffset, u8 palOffset)
@@ -279,7 +285,11 @@ const u16 *GetTextWindowPalette(u8 id)
 
 const u16 *GetOverworldTextboxPalettePtr(void)
 {
+#ifdef PLATFORM_PC
+    return LoadTextWindowPalette(0);
+#else
     return gMessageBox_Pal;
+#endif
 }
 
 // Effectively LoadUserWindowBorderGfx but specifying the bg directly instead of a window from that bg


### PR DESCRIPTION
## Summary
- Load message box frame graphics from PNGs at runtime on PC
- Drop message box INCBIN data and add shim palette/tile constants

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68967c6347e48324b98334f4d8aa17e5