### PR TITLE
Load rotating ball asset at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -23,3 +23,4 @@
 - Added PNG to 4bpp tile conversion with caching in the PC asset loader and updated `LoadMiscBlankGfx` to use runtime-loaded tiles.
 - Extracted palettes from PNGs in the asset loader and switched text window frames and palettes to load at runtime, removing INCBIN dependencies for the PC build.
 - Replaced message box graphics and palette with PNG-based runtime loading, removed corresponding INCBIN data, and extended PC GBA shims with tile and palette size macros so text windows compile on desktop.
+- Switched rotating pocket indicator to load PNG graphics and palette at runtime, removed INCBIN assets from item menu icons, and expanded PC GBA shims with basic BG VRAM macros for desktop compilation.

--- a/platform/pc/gba/defines.h
+++ b/platform/pc/gba/defines.h
@@ -37,6 +37,12 @@ extern struct SoundInfo *gSoundInfoPtr;
 #define PLTT_SIZE_4BPP PLTT_SIZEOF(16)
 #define PLTT_OFFSET_4BPP(n) ((n) * PLTT_SIZE_4BPP)
 
+#define BG_VRAM        0
+#define BG_CHAR_SIZE   0x4000
+#define BG_SCREEN_SIZE 0x800
+#define BG_CHAR_ADDR(n)   (BG_VRAM + (BG_CHAR_SIZE * (n)))
+#define BG_SCREEN_ADDR(n) (BG_VRAM + (BG_SCREEN_SIZE * (n)))
+
 #define DISPLAY_WIDTH  240
 #define DISPLAY_HEIGHT 160
 

--- a/src/item_menu_icons.c
+++ b/src/item_menu_icons.c
@@ -11,6 +11,10 @@
 #include "window.h"
 #include "constants/items.h"
 
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
+
 enum {
     TAG_BAG_GFX = 100,
     TAG_ROTATING_BALL_GFX,
@@ -33,10 +37,34 @@ static void SpriteCB_SwitchPocketRotatingBallInit(struct Sprite *sprite);
 static void SpriteCB_SwitchPocketRotatingBallContinue(struct Sprite *sprite);
 
 // static const rom data
+#ifdef PLATFORM_PC
+static struct SpriteSheet sRotatingBallTable = { NULL, 0, TAG_ROTATING_BALL_GFX };
+static struct SpritePalette sRotatingBallPaletteTable = { NULL, TAG_ROTATING_BALL_GFX };
+static void LoadRotatingBallGfx(void)
+{
+    if (!sRotatingBallTable.data)
+    {
+        size_t size = 0;
+        sRotatingBallTable.data = AssetsLoad4bpp("graphics/bag/rotating_ball.png", NULL, &size);
+        sRotatingBallTable.size = (u16)size;
+    }
+    if (!sRotatingBallPaletteTable.data)
+        sRotatingBallPaletteTable.data = AssetsGetPNGPalette("graphics/bag/rotating_ball.png", NULL);
+}
+#else
 static const u16 sRotatingBall_Pal[] = INCBIN_U16("graphics/bag/rotating_ball.gbapal");
 static const u8 sRotatingBall_Gfx[] = INCBIN_U8("graphics/bag/rotating_ball.4bpp");
 static const u8 sCherryUnused[] = INCBIN_U8("graphics/unused/cherry.4bpp");
 static const u16 sCherryUnused_Pal[] = INCBIN_U16("graphics/unused/cherry.gbapal");
+static const struct SpriteSheet sRotatingBallTable =
+{
+    sRotatingBall_Gfx, sizeof(sRotatingBall_Gfx), TAG_ROTATING_BALL_GFX
+};
+static const struct SpritePalette sRotatingBallPaletteTable =
+{
+    sRotatingBall_Pal, TAG_ROTATING_BALL_GFX
+};
+#endif
 
 static const struct OamData sBagOamData =
 {
@@ -203,15 +231,6 @@ static const union AffineAnimCmd *const sRotatingBallAnimCmds_FullRotation[] =
     sSpriteAffineAnim_RotatingBallRotation2,
 };
 
-static const struct SpriteSheet sRotatingBallTable =
-{
-    sRotatingBall_Gfx, sizeof(sRotatingBall_Gfx), TAG_ROTATING_BALL_GFX
-};
-
-static const struct SpritePalette sRotatingBallPaletteTable =
-{
-    sRotatingBall_Pal, TAG_ROTATING_BALL_GFX
-};
 
 static const struct SpriteTemplate sRotatingBallSpriteTemplate =
 {
@@ -497,6 +516,9 @@ static void SpriteCB_ShakeBagSprite(struct Sprite *sprite)
 void AddSwitchPocketRotatingBallSprite(s16 rotationDirection)
 {
     u8 *spriteId = &gBagMenu->spriteIds[ITEMMENUSPRITE_BALL];
+#ifdef PLATFORM_PC
+    LoadRotatingBallGfx();
+#endif
     LoadSpriteSheet(&sRotatingBallTable);
     LoadSpritePalette(&sRotatingBallPaletteTable);
     *spriteId = CreateSprite(&sRotatingBallSpriteTemplate, 16, 16, 0);


### PR DESCRIPTION
## Summary
- Replace bag rotating-ball sprites with PNG-based runtime loading on PC builds
- Add basic background VRAM macros to PC GBA shim for broader source compatibility

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68967e8a96248324a036b498920821fd