### PR TITLE
Load weather assets from PNG

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -24,3 +24,4 @@
 - Extracted palettes from PNGs in the asset loader and switched text window frames and palettes to load at runtime, removing INCBIN dependencies for the PC build.
 - Replaced message box graphics and palette with PNG-based runtime loading, removed corresponding INCBIN data, and extended PC GBA shims with tile and palette size macros so text windows compile on desktop.
 - Switched rotating pocket indicator to load PNG graphics and palette at runtime, removed INCBIN assets from item menu icons, and expanded PC GBA shims with basic BG VRAM macros for desktop compilation.
+- Began migrating weather assets to runtime loading by pulling the cloud palette and tiles from PNGs, extracting the sandstorm palette, and preparing the cloud sprite sheet for PC builds; remaining weather graphics still use placeholders.


### PR DESCRIPTION
## Summary
- Load cloud weather palette and tiles from PNG at runtime and prep cloud sprite sheet for PC builds
- Extract sandstorm palette from PNG to begin weather runtime asset support
- Note: other weather graphics still use placeholders pending runtime loaders

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_689680938a648324b54db24142d81b9c