### PR TITLE
Add PC flash save emulation

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -28,3 +28,4 @@
 - Completed weather asset migration by loading the fog palette from file, replacing all remaining weather tile INCBINs (fog, snow, bubbles, ash, rain, sandstorm) with PNG-based runtime loading and dynamic sprite sheets, and updating battle animations to use the new data.
 - Migrated Pokédex cry screen assets to runtime loading, decoding PNG graphics and palettes for the cry meter needle, meter, and background, removing the remaining INCBIN data.
 - Converted list menu interface assets (scroll arrows and red cursors) to runtime-loaded PNG graphics and palettes, eliminating their INCBIN data and leveraging the shared red UI palette.
+- Implemented file-based flash save emulation for PC builds, adding platform/pc/flash.c to map GBA flash sectors to a saves/slot0.sav file and updating the PC Makefile.

--- a/platform/pc/Makefile.pc
+++ b/platform/pc/Makefile.pc
@@ -17,6 +17,7 @@ PC_SRCS := platform/pc/platform.c \
            platform/pc/timer.c \
            platform/pc/fs.c \
            platform/pc/assets.c \
+           platform/pc/flash.c \
            platform/pc/syscalls.c \
            platform/pc/game_loop_stub.c \
            platform/pc/m4a_stub.c \

--- a/platform/pc/flash.c
+++ b/platform/pc/flash.c
@@ -1,0 +1,105 @@
+#include "global.h"
+#include "fs.h"
+#include "save.h"
+#include "agb_flash.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static const char *GetSaveFilePath(void)
+{
+    static char sPath[256];
+    const char *dir = FsGetSavePath();
+    snprintf(sPath, sizeof(sPath), "%s/slot0.sav", dir);
+    return sPath;
+}
+
+static void EnsureSaveFile(void)
+{
+    const char *dir = FsGetSavePath();
+#ifdef _WIN32
+    _mkdir(dir);
+#else
+    mkdir(dir, 0755);
+#endif
+    const char *path = GetSaveFilePath();
+    FILE *f = fopen(path, "rb");
+    if (f == NULL)
+    {
+        f = fopen(path, "wb");
+        if (f != NULL)
+        {
+            u8 blank[SECTOR_SIZE];
+            memset(blank, 0xFF, sizeof(blank));
+            for (int i = 0; i < SECTORS_COUNT; i++)
+                fwrite(blank, 1, sizeof(blank), f);
+            fclose(f);
+        }
+    }
+    else
+    {
+        fclose(f);
+    }
+}
+
+u16 IdentifyFlash(void)
+{
+    EnsureSaveFile();
+    return 0;
+}
+
+u16 SetFlashTimerIntr(u8 timerNum, void (**intrFunc)(void))
+{
+    (void)timerNum;
+    (void)intrFunc;
+    return 0;
+}
+
+void ReadFlash(u16 sectorNum, u32 offset, u8 *dest, u32 size)
+{
+    EnsureSaveFile();
+    FILE *f = fopen(GetSaveFilePath(), "rb");
+    if (f == NULL)
+    {
+        memset(dest, 0xFF, size);
+        return;
+    }
+    fseek(f, sectorNum * SECTOR_SIZE + offset, SEEK_SET);
+    size_t readBytes = fread(dest, 1, size, f);
+    (void)readBytes;
+    fclose(f);
+}
+
+u32 ProgramFlashSectorAndVerify(u16 sectorNum, u8 *src)
+{
+    EnsureSaveFile();
+    FILE *f = fopen(GetSaveFilePath(), "rb+");
+    if (f == NULL)
+        return 1;
+    fseek(f, sectorNum * SECTOR_SIZE, SEEK_SET);
+    size_t written = fwrite(src, 1, SECTOR_SIZE, f);
+    fflush(f);
+    fclose(f);
+    return written == SECTOR_SIZE ? 0 : 1;
+}
+
+static u16 PcEraseFlashSector(u16 sectorNum)
+{
+    EnsureSaveFile();
+    FILE *f = fopen(GetSaveFilePath(), "rb+");
+    if (f == NULL)
+        return 1;
+    u8 blank[SECTOR_SIZE];
+    memset(blank, 0xFF, sizeof(blank));
+    fseek(f, sectorNum * SECTOR_SIZE, SEEK_SET);
+    fwrite(blank, 1, sizeof(blank), f);
+    fflush(f);
+    fclose(f);
+    return 0;
+}
+
+u16 (*EraseFlashSector)(u16) = PcEraseFlashSector;
+


### PR DESCRIPTION
## Summary
- Emulate GBA flash memory for desktop builds by mapping flash sectors to a saves/slot0.sav file.
- Update PC build system to compile the new flash module.

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68968df38ca083249812a292d5b22a59