### PR TITLE
Load summary screen assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -29,3 +29,4 @@
 - Migrated Pokédex cry screen assets to runtime loading, decoding PNG graphics and palettes for the cry meter needle, meter, and background, removing the remaining INCBIN data.
 - Converted list menu interface assets (scroll arrows and red cursors) to runtime-loaded PNG graphics and palettes, eliminating their INCBIN data and leveraging the shared red UI palette.
 - Implemented file-based flash save emulation for PC builds, adding platform/pc/flash.c to map GBA flash sectors to a saves/slot0.sav file and updating the PC Makefile.
+- Converted Pokémon summary screen assets to runtime loading for PC builds, loading the status tilemap, A/B button graphics, and markings palette from external files to eliminate remaining INCBIN data.


### PR DESCRIPTION
## Summary
- Load summary screen status tilemap from external file on PC builds
- Replace A/B button INCBINs with PNG-based runtime loading
- Use external palette for markings and invoke loader during summary screen setup

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_689691ca502c83249859f49116382310