### PR TITLE
Load drought weather color tables at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -31,3 +31,4 @@
 - Implemented file-based flash save emulation for PC builds, adding platform/pc/flash.c to map GBA flash sectors to a saves/slot0.sav file and updating the PC Makefile.
 - Converted Pokémon summary screen assets to runtime loading for PC builds, loading the status tilemap, A/B button graphics, and markings palette from external files to eliminate remaining INCBIN data.
 - Migrated wireless minigame countdown graphics to load PNG sprites and palettes at runtime for PC builds, removing INCBIN dependencies.
+- Loaded drought weather color lookup tables from external binaries for PC builds, eliminating remaining INCBIN data for the drought effect.


### PR DESCRIPTION
## Summary
- Load drought weather color lookup tables from external files to eliminate embedded INCBIN data on PC
- Use new loader in drought palette blending routines
- Log drought color table migration

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68969667d94483249b57513f728a7969