### PR TITLE
Load move relearner UI assets at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -33,3 +33,4 @@
 - Migrated wireless minigame countdown graphics to load PNG sprites and palettes at runtime for PC builds, removing INCBIN dependencies.
 - Loaded drought weather color lookup tables from external binaries for PC builds, eliminating remaining INCBIN data for the drought effect.
 - Replaced Mystery Gift menu textbox border INCBIN data with runtime PNG loading for graphics and palette to advance PC asset migration.
+- Converted Move Relearner interface graphics and palette to load from PNG at runtime on PC builds, eliminating remaining INCBIN assets for that menu.

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -24,6 +24,9 @@
 #include "task.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
 
 /*
  * Move relearner state machine
@@ -181,11 +184,32 @@ static EWRAM_DATA struct {
     bool8 showContestInfo;
 } sMoveRelearnerMenuState = {0};
 
+#ifdef PLATFORM_PC
+static const u16 *LoadMoveRelearnerUIPal(void)
+{
+    static const u16 *sPal;
+    if (!sPal)
+        sPal = AssetsGetPNGPalette("graphics/interface/ui_learn_move.png", NULL);
+    return sPal;
+}
+
+static const u8 *LoadMoveRelearnerUITiles(size_t *size)
+{
+    static const u8 *sGfx;
+    static size_t sSize;
+    if (!sGfx)
+        sGfx = AssetsLoad4bpp("graphics/interface/ui_learn_move.png", NULL, &sSize);
+    if (size)
+        *size = sSize;
+    return sGfx;
+}
+#else
 static const u16 sUI_Pal[] = INCBIN_U16("graphics/interface/ui_learn_move.gbapal");
 
 // The arrow sprites in this spritesheet aren't used. The scroll-arrow system provides its own
 // arrow sprites.
 static const u8 sUI_Tiles[] = INCBIN_U8("graphics/interface/ui_learn_move.4bpp");
+#endif
 
 static const struct OamData sHeartSpriteOamData =
 {
@@ -238,6 +262,21 @@ static const struct OamData sUnusedOam2 =
     .affineParam = 0,
 };
 
+#ifdef PLATFORM_PC
+static struct SpriteSheet sMoveRelearnerSpriteSheet;
+static struct SpritePalette sMoveRelearnerPalette;
+
+static void LoadMoveRelearnerUIAssets(void)
+{
+    size_t size;
+    sMoveRelearnerSpriteSheet.data = LoadMoveRelearnerUITiles(&size);
+    sMoveRelearnerSpriteSheet.size = size;
+    sMoveRelearnerSpriteSheet.tag = GFXTAG_UI;
+
+    sMoveRelearnerPalette.data = LoadMoveRelearnerUIPal();
+    sMoveRelearnerPalette.tag = PALTAG_UI;
+}
+#else
 static const struct SpriteSheet sMoveRelearnerSpriteSheet =
 {
     .data = sUI_Tiles,
@@ -250,6 +289,7 @@ static const struct SpritePalette sMoveRelearnerPalette =
     .data = sUI_Pal,
     .tag = PALTAG_UI
 };
+#endif
 
 static const struct ScrollArrowsTemplate sDisplayModeArrowsTemplate =
 {
@@ -407,6 +447,9 @@ static void CB2_InitLearnMove(void)
 
     CreateLearnableMovesList();
 
+    #ifdef PLATFORM_PC
+    LoadMoveRelearnerUIAssets();
+    #endif
     LoadSpriteSheet(&sMoveRelearnerSpriteSheet);
     LoadSpritePalette(&sMoveRelearnerPalette);
     CreateUISprites();
@@ -432,6 +475,9 @@ static void CB2_InitLearnMoveReturnFromSelectMove(void)
     InitMoveRelearnerWindows(sMoveRelearnerMenuState.showContestInfo);
     CreateLearnableMovesList();
 
+    #ifdef PLATFORM_PC
+    LoadMoveRelearnerUIAssets();
+    #endif
     LoadSpriteSheet(&sMoveRelearnerSpriteSheet);
     LoadSpritePalette(&sMoveRelearnerPalette);
     CreateUISprites();


### PR DESCRIPTION
## Summary
- Load Move Relearner menu graphics and palette from PNG via PC asset system instead of using baked INCBIN data
- Document the new runtime asset loading in the agent log

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_68969a0d3b988324a85e6f494a408353