### PR TITLE
Load Pokenav main menu assets at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -37,3 +37,4 @@
 - Converted Option Menu text palette and equals sign graphic to load from external files at runtime for PC builds, removing INCBIN data from that menu.
 - Converted Save Failed screen clock graphics and palette to load from PNG at runtime for PC builds, eliminating corresponding INCBIN data.
 - Converted battle environment backgrounds to load tilesets, tilemaps, and palettes from external files at runtime on PC builds, removing INCBIN dependencies and enabling dynamic battlefield rendering.
+- Migrated Pokénav main menu spinning icon graphics and palette to load from PNG at runtime for PC builds, eliminating INCBIN data and preparing dynamic sprite sheet usage.

--- a/src/pokenav_main_menu.c
+++ b/src/pokenav_main_menu.c
@@ -12,6 +12,9 @@
 #include "gpu_regs.h"
 #include "menu.h"
 #include "dma3.h"
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
 
 struct Pokenav_MainMenu
 {
@@ -52,10 +55,35 @@ static u32 LoopedTask_SlideMenuHeaderDown(s32);
 static void DrawHelpBar(u32);
 static void SpriteCB_SpinningPokenav(struct Sprite *);
 static u32 LoopedTask_InitPokenavMenu(s32);
+#ifdef PLATFORM_PC
+static struct SpriteSheet sSpinningPokenavSpriteSheet[] =
+{
+    { NULL, 0, 0 },
+    {},
+};
 
+static struct SpritePalette sSpinningNavgearPalettes[] =
+{
+    { NULL, 0 },
+    {},
+};
+
+static void LoadSpinningPokenavAssets(void)
+{
+    if (!sSpinningPokenavSpriteSheet[0].data)
+    {
+        size_t size = 0;
+        sSpinningPokenavSpriteSheet[0].data = AssetsLoad4bpp("graphics/pokenav/nav_icon.png", NULL, &size);
+        sSpinningPokenavSpriteSheet[0].size = (u16)size;
+    }
+    if (!sSpinningNavgearPalettes[0].data)
+        sSpinningNavgearPalettes[0].data = AssetsGetPNGPalette("graphics/pokenav/nav_icon.png", NULL);
+}
+#else
 static const u16 sSpinningPokenav_Pal[] = INCBIN_U16("graphics/pokenav/nav_icon.gbapal");
 static const u32 sSpinningPokenav_Gfx[] = INCBIN_U32("graphics/pokenav/nav_icon.4bpp.lz");
 static const u32 sBlueLightCopy[] = INCBIN_U32("graphics/pokenav/blue_light.4bpp.lz"); // Unused copy of sMatchCallBlueLightTiles
+#endif
 
 const struct BgTemplate gPokenavMainMenuBgTemplates[] =
 {
@@ -105,6 +133,9 @@ static const u8 sHelpBarTextColors[3] =
     TEXT_COLOR_RED, TEXT_COLOR_WHITE, TEXT_COLOR_DARK_GRAY
 };
 
+#ifdef PLATFORM_PC
+// Definitions for PC builds are provided above and loaded at runtime
+#else
 static const struct CompressedSpriteSheet sSpinningPokenavSpriteSheet[] =
 {
     {
@@ -122,6 +153,7 @@ static const struct SpritePalette sSpinningNavgearPalettes[] =
     },
     {}
 };
+#endif
 
 static const struct CompressedSpriteSheet sMenuLeftHeaderSpriteSheet =
 {
@@ -582,10 +614,14 @@ static void InitPokenavMainMenuResources(void)
     s32 i;
     u8 spriteId;
     struct Pokenav_MainMenu *menu = GetSubstructPtr(POKENAV_SUBSTRUCT_MAIN_MENU);
-
+#ifdef PLATFORM_PC
+    LoadSpinningPokenavAssets();
+    for (i = 0; sSpinningPokenavSpriteSheet[i].data != NULL; i++)
+        LoadSpriteSheet(&sSpinningPokenavSpriteSheet[i]);
+#else
     for (i = 0; i < ARRAY_COUNT(sSpinningPokenavSpriteSheet); i++)
         LoadCompressedSpriteSheet(&sSpinningPokenavSpriteSheet[i]);
-
+#endif
     Pokenav_AllocAndLoadPalettes(sSpinningNavgearPalettes);
     menu->palettes = ~1 & ~(0x10000 << IndexOfSpritePaletteTag(0));
     spriteId = CreateSprite(&sSpinningPokenavSpriteTemplate, 220, 12, 0);


### PR DESCRIPTION
## Summary
- Load Pokénav main menu spinning icon graphics and palette from PNGs at runtime on PC builds
- Initialize sprite sheet and palette dynamically, removing INCBIN dependencies

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896a64c5b988324b7f260043e8e9548