### PR TITLE
Load cave transition assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -40,3 +40,4 @@
 - Migrated Pokénav main menu spinning icon graphics and palette to load from PNG at runtime for PC builds, eliminating INCBIN data and preparing dynamic sprite sheet usage.
 - Converted Pokéball battle transition assets to runtime loading for PC builds, decoding big Pokéball and trail graphics and palette from external files to replace remaining INCBIN data.
 - Converted Trainer Card interfaces to runtime asset loading on PC, pulling tilemaps, tiles, and palettes from external files and removing related INCBIN data.
+- Migrated cave transition graphics in `fldeff_flash.c` to runtime PNG and palette loading for PC builds, eliminating INCBIN usage for tiles, tilemap, and palettes.


### PR DESCRIPTION
## Summary
- Load cave transition palettes, tiles, and tilemap from external files when building for PC
- Document cave transition migration in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896af8c8740832489dfd5d9ec8ae461