### PR TITLE
Load RTC screen arrows from PNG in PC build

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -43,3 +43,4 @@
 - Migrated cave transition graphics in `fldeff_flash.c` to runtime PNG and palette loading for PC builds, eliminating INCBIN usage for tiles, tilemap, and palettes.
 - Converted secret base field effects and record mixing lights to runtime PNG and palette loading on PC, replacing INCBIN assets for secret power entrances, sand pillars, and cable-club lights.
 - Converted Battle Frontier circle transition assets to runtime PNG loading on PC, replacing INCBIN graphics, tilemap, and palette for the logo animation.
+- Converted Reset RTC screen cursor arrows to load PNG graphics and palette at runtime on PC builds, removing INCBIN data for the arrow sprites.

--- a/src/reset_rtc_screen.c
+++ b/src/reset_rtc_screen.c
@@ -18,6 +18,9 @@
 #include "window.h"
 #include "gpu_regs.h"
 #include "constants/rgb.h"
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
 
 #define PALTAG_ARROW 0x1000
 
@@ -176,6 +179,27 @@ static const struct OamData sOamData_Arrow =
     .affineParam = 0,
 };
 
+#ifdef PLATFORM_PC
+static struct SpriteFrameImage sPicTable_Arrow[2];
+static struct SpritePalette sSpritePalette_Arrow = { NULL, PALTAG_ARROW };
+
+static void LoadResetRtcArrowAssets(void)
+{
+    size_t size = 0;
+    if (!sPicTable_Arrow[0].data)
+    {
+        sPicTable_Arrow[0].data = AssetsLoad4bpp("graphics/reset_rtc_screen/arrow_down.png", NULL, &size);
+        sPicTable_Arrow[0].size = (u16)size;
+    }
+    if (!sPicTable_Arrow[1].data)
+    {
+        sPicTable_Arrow[1].data = AssetsLoad4bpp("graphics/reset_rtc_screen/arrow_right.png", NULL, &size);
+        sPicTable_Arrow[1].size = (u16)size;
+    }
+    if (!sSpritePalette_Arrow.data)
+        sSpritePalette_Arrow.data = AssetsLoadPal("graphics/reset_rtc_screen/arrow.pal", NULL);
+}
+#else
 static const u8 sArrowDown_Gfx[] = INCBIN_U8("graphics/reset_rtc_screen/arrow_down.4bpp");
 static const u8 sArrowRight_Gfx[] = INCBIN_U8("graphics/reset_rtc_screen/arrow_right.4bpp");
 static const u16 sArrow_Pal[] = INCBIN_U16("graphics/reset_rtc_screen/arrow.gbapal");
@@ -190,6 +214,7 @@ static const struct SpritePalette sSpritePalette_Arrow =
 {
     sArrow_Pal, PALTAG_ARROW
 };
+#endif
 
 static const union AnimCmd sAnim_Arrow_Down[] =
 {
@@ -338,6 +363,9 @@ static void CreateCursor(u8 taskId)
 {
     u32 spriteId;
 
+#ifdef PLATFORM_PC
+    LoadResetRtcArrowAssets();
+#endif
     LoadSpritePalette(&sSpritePalette_Arrow);
 
     spriteId = CreateSpriteAtEnd(&sSpriteTemplate_Arrow, 53, 68, 0);


### PR DESCRIPTION
## Summary
- Load Reset RTC screen cursor arrow graphics and palette from external PNG/JASC files during PC builds
- Document change in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896b87ad2808324a1fd9f540d64b993