### PR TITLE
Load Match Call assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -45,3 +45,4 @@
 - Converted Battle Frontier circle transition assets to runtime PNG loading on PC, replacing INCBIN graphics, tilemap, and palette for the logo animation.
 - Converted Reset RTC screen cursor arrows to load PNG graphics and palette at runtime on PC builds, removing INCBIN data for the arrow sprites.
 - Converted contest results screen text window assets to runtime-loaded PNG graphics and palette for PC builds, eliminating embedded INCBIN data.
+- Converted Pokénav Match Call window and icon assets to load PNG graphics and palettes at runtime for PC builds, removing INCBIN dependencies.


### PR DESCRIPTION
## Summary
- Load Pokénav Match Call window graphics and palette from external PNG/JASC files
- Load Match Call nav icon graphics and palette at runtime on PC builds

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896bd62cca083249903568dfc2964e0