### PR TITLE
Load Match Call UI assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -46,3 +46,4 @@
 - Converted Reset RTC screen cursor arrows to load PNG graphics and palette at runtime on PC builds, removing INCBIN data for the arrow sprites.
 - Converted contest results screen text window assets to runtime-loaded PNG graphics and palette for PC builds, eliminating embedded INCBIN data.
 - Converted Pokénav Match Call window and icon assets to load PNG graphics and palettes at runtime for PC builds, removing INCBIN dependencies.
+- Converted remaining Pokénav Match Call interface assets to load tiles, tilemaps, and palettes from external PNGs at runtime on PC builds, removing INCBIN references for the UI, cursor, windows, and Pokéball icons.


### PR DESCRIPTION
## Summary
- Replace Pokénav Match Call interface INCBIN data with runtime asset loading on PC.
- Load match call UI, cursor, window palettes, and Pokéball icons from external PNG resources.
- Update Match Call opening logic and sprite allocation to use the new asset loading helpers.

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896bf48a6108324bc6a1fd087b271f8