### PR TITLE
Load naming screen PC icon assets at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -48,3 +48,4 @@
 - Converted Pokénav Match Call window and icon assets to load PNG graphics and palettes at runtime for PC builds, removing INCBIN dependencies.
 - Converted remaining Pokénav Match Call interface assets to load tiles, tilemaps, and palettes from external PNGs at runtime on PC builds, removing INCBIN references for the UI, cursor, windows, and Pokéball icons.
 - Converted Pokénav condition graph and search results screens to load tiles, tilemaps, and palettes from external files at runtime on PC builds, eliminating remaining INCBIN data for those interfaces.
+- Converted naming screen PC icon graphics and keyboard palette to load from external PNG and palette files at runtime on PC builds, removing corresponding INCBIN data.


### PR DESCRIPTION
## Summary
- Load naming screen PC icon graphics from external PNGs on the desktop build
- Fetch keyboard palette at runtime for PC builds to eliminate embedded assets

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896c4b517648324a98a452114eba720