### PR TITLE
Load naming screen UI assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -49,3 +49,4 @@
 - Converted remaining Pokénav Match Call interface assets to load tiles, tilemaps, and palettes from external PNGs at runtime on PC builds, removing INCBIN references for the UI, cursor, windows, and Pokéball icons.
 - Converted Pokénav condition graph and search results screens to load tiles, tilemaps, and palettes from external files at runtime on PC builds, eliminating remaining INCBIN data for those interfaces.
 - Converted naming screen PC icon graphics and keyboard palette to load from external PNG and palette files at runtime on PC builds, removing corresponding INCBIN data.
+- Converted naming screen menu, buttons, cursor, and related sprites to load graphics and palettes from external files at runtime on PC builds, removing remaining INCBIN data for those assets.

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1390,6 +1390,7 @@ const u16 gStorageSystemPartyMenu_Pal[] = INCBIN_U16("graphics/pokemon_storage/p
 const u32 gStorageSystemPartyMenu_Tilemap[] = INCBIN_U32("graphics/pokemon_storage/party_menu.bin.lz");
 
 // naming screen
+#ifndef PLATFORM_PC
 
 const u16 gNamingScreenMenu_Pal[6][16] =
 {
@@ -1413,6 +1414,7 @@ const u32 gNamingScreenCursorFilled_Gfx[]        = INCBIN_U32("graphics/naming_s
 const u32 gNamingScreenPageSwapButton_Gfx[]      = INCBIN_U32("graphics/naming_screen/page_swap_button.4bpp");
 const u32 gNamingScreenInputArrow_Gfx[]          = INCBIN_U32("graphics/naming_screen/input_arrow.4bpp");
 const u32 gNamingScreenUnderscore_Gfx[]          = INCBIN_U32("graphics/naming_screen/underscore.4bpp");
+#endif // PLATFORM_PC
 const u32 gNamingScreenBackground_Tilemap[]      = INCBIN_U32("graphics/naming_screen/background.bin.lz");
 const u32 gNamingScreenKeyboardUpper_Tilemap[]   = INCBIN_U32("graphics/naming_screen/keyboard_upper.bin.lz");
 const u32 gNamingScreenKeyboardLower_Tilemap[]   = INCBIN_U32("graphics/naming_screen/keyboard_lower.bin.lz");


### PR DESCRIPTION
## Summary
- Load naming screen menu graphics from PNG at runtime on PC
- Replace static naming screen palettes and sprites with cached runtime loading
- Omit naming screen INCBIN assets from PC build

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896c66686108324a138e5fdde8f931b