### PR TITLE
Load main menu palettes at runtime

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -52,3 +52,4 @@
 - Converted naming screen menu, buttons, cursor, and related sprites to load graphics and palettes from external files at runtime on PC builds, removing remaining INCBIN data for those assets.
 - Converted Pokénav list arrow graphics and palette to load from PNG at runtime on PC builds, eliminating remaining INCBIN data in pokenav_list.c.
 - Converted standard menu and Hall of Fame PC top bar palettes to load from external .pal files on PC builds, removing INCBIN data from menu.c and enabling runtime palette loading.
+- Converted main menu background and text palettes to load from external .pal files at runtime on PC builds, removing INCBIN data from main_menu.c.

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -403,8 +403,28 @@ static const struct WindowTemplate sNewGameBirchSpeechTextWindows[] =
     DUMMY_WIN_TEMPLATE
 };
 
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+
+static const u16 *LoadMainMenuBgPal(void)
+{
+    static const u16 *sPal;
+    if (!sPal)
+        sPal = AssetsLoadPal("graphics/interface/main_menu_bg.pal", NULL);
+    return sPal;
+}
+
+static const u16 *LoadMainMenuTextPal(void)
+{
+    static const u16 *sPal;
+    if (!sPal)
+        sPal = AssetsLoadPal("graphics/interface/main_menu_text.pal", NULL);
+    return sPal;
+}
+#else
 static const u16 sMainMenuBgPal[] = INCBIN_U16("graphics/interface/main_menu_bg.gbapal");
 static const u16 sMainMenuTextPal[] = INCBIN_U16("graphics/interface/main_menu_text.gbapal");
+#endif
 
 static const u8 sTextColor_Headers[] = {TEXT_DYNAMIC_COLOR_1, TEXT_DYNAMIC_COLOR_2, TEXT_DYNAMIC_COLOR_3};
 static const u8 sTextColor_MenuInfo[] = {TEXT_DYNAMIC_COLOR_1, TEXT_COLOR_WHITE, TEXT_DYNAMIC_COLOR_3};
@@ -574,8 +594,13 @@ static u32 InitMainMenu(bool8 returningFromOptionsMenu)
     DmaFill16(3, 0, (void *)(PLTT + 2), PLTT_SIZE - 2);
 
     ResetPaletteFade();
+#ifdef PLATFORM_PC
+    LoadPalette(LoadMainMenuBgPal(), BG_PLTT_ID(0), PLTT_SIZE_4BPP);
+    LoadPalette(LoadMainMenuTextPal(), BG_PLTT_ID(15), PLTT_SIZE_4BPP);
+#else
     LoadPalette(sMainMenuBgPal, BG_PLTT_ID(0), PLTT_SIZE_4BPP);
     LoadPalette(sMainMenuTextPal, BG_PLTT_ID(15), PLTT_SIZE_4BPP);
+#endif
     ScanlineEffect_Stop();
     ResetTasks();
     ResetSpriteData();


### PR DESCRIPTION
## Summary
- Load main menu background palette from external file on PC builds
- Load main menu text palette from external file on PC builds
- Document this change in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896cc505c408324abf3499fc52bcee0