### PR TITLE
Load map name popup assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -54,3 +54,4 @@
 - Converted standard menu and Hall of Fame PC top bar palettes to load from external .pal files on PC builds, removing INCBIN data from menu.c and enabling runtime palette loading.
 - Converted main menu background and text palettes to load from external .pal files at runtime on PC builds, removing INCBIN data from main_menu.c.
 - Converted trainer emotion icons to load PNG graphics at runtime on PC builds, replacing embedded INCBIN data in trainer_see.c.
+- Converted map name popup themes to load tiles, outlines, and palettes from external PNG and PAL files at runtime on PC builds, removing INCBIN dependencies in map_name_popup.c.


### PR DESCRIPTION
## Summary
- Load map name popup themes from external PNG and PAL files on PC builds
- Document runtime map popup asset loading in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896d181e2108324a9ff5d3bce498295