### PR TITLE
Load rotating gate tiles from PNGs for PC builds

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -55,3 +55,4 @@
 - Converted main menu background and text palettes to load from external .pal files at runtime on PC builds, removing INCBIN data from main_menu.c.
 - Converted trainer emotion icons to load PNG graphics at runtime on PC builds, replacing embedded INCBIN data in trainer_see.c.
 - Converted map name popup themes to load tiles, outlines, and palettes from external PNG and PAL files at runtime on PC builds, removing INCBIN dependencies in map_name_popup.c.
+- Converted rotating gate puzzle graphics to load gate tiles from PNG at runtime on PC builds, eliminating INCBIN data in rotating_gate.c.


### PR DESCRIPTION
## Summary
- Load rotating gate gate graphics from runtime PNGs on PC builds instead of embedded INCBIN data.
- Document rotating gate PNG asset loading in AGENTS_LOG.

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896d353be40832487bbc24be79a50f6