### PR TITLE
Load mystery gift assets at runtime on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -57,3 +57,4 @@
 - Converted map name popup themes to load tiles, outlines, and palettes from external PNG and PAL files at runtime on PC builds, removing INCBIN dependencies in map_name_popup.c.
 - Converted rotating gate puzzle graphics to load gate tiles from PNG at runtime on PC builds, eliminating INCBIN data in rotating_gate.c.
 - Converted diploma screen assets to load tiles, tilemap, and palettes from external files at runtime on PC builds, removing INCBIN usage in diploma.c.
+- Migrated Wonder Card and Wonder News interfaces to load backgrounds, tilemaps, palettes, and stamp graphics from external files at runtime on PC builds, eliminating INCBIN data in mystery_gift_view.c.


### PR DESCRIPTION
## Summary
- Runtime-load Wonder Card and Wonder News backgrounds, tilemaps, palettes and stamp graphics on PC builds
- Replace inlined mystery gift INCBIN assets with SDL-driven file loading

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6896d684252083249687d2ff9c8a91f0