### PR TITLE
Load contest and berry tag palettes from files

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -62,3 +62,4 @@
 - Converted PokéNav main menu backgrounds and blue light to load tiles, tilemaps, and palettes from external files at runtime on PC builds, removing INCBIN assets in pokenav_menu_handler_gfx.c and loading option palettes dynamically.
 - Removed duplicate sprite sheet and palette definitions in pokenav_menu_handler_gfx.c to finalize PokéNav main menu runtime loading.
 - Converted PokéNav ribbon list and ribbon summary assets to load graphics, tilemaps, and palettes from external files at runtime on PC builds, eliminating INCBIN data and enabling dynamic ribbon icons.
+- Converted Contest text palette and Berry Tag screen font palette to load from external .pal files at runtime on PC builds, removing corresponding INCBIN data.

--- a/src/berry_tag_screen.c
+++ b/src/berry_tag_screen.c
@@ -29,6 +29,9 @@
 #include "constants/items.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
 
 // There are 4 windows used in berry tag screen.
 enum
@@ -92,7 +95,17 @@ static const struct BgTemplate sBackgroundTemplates[] =
   }
 };
 
+#ifdef PLATFORM_PC
+static const u16 *LoadBerryTagScreenPal(void)
+{
+    static const u16 *sPal;
+    if (!sPal)
+        sPal = AssetsLoadPal("graphics/bag/berry_tag_screen.pal", NULL);
+    return sPal;
+}
+#else
 static const u16 sFontPalette[] = INCBIN_U16("graphics/bag/berry_tag_screen.gbapal");
+#endif
 
 static const u8 sTextColors[2][3] =
 {
@@ -370,7 +383,19 @@ static void HandleInitWindows(void)
 
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadPalette(sFontPalette, BG_PLTT_ID(15), sizeof(sFontPalette));
+    LoadPalette(
+#ifdef PLATFORM_PC
+                LoadBerryTagScreenPal(),
+#else
+                sFontPalette,
+#endif
+                BG_PLTT_ID(15),
+#ifdef PLATFORM_PC
+                PLTT_SIZEOF(16)
+#else
+                sizeof(sFontPalette)
+#endif
+    );
     for (i = 0; i < ARRAY_COUNT(sWindowTemplates) - 1; i++)
         PutWindowTilemap(i);
     ScheduleBgCopyTilemapToVram(0);

--- a/src/contest.c
+++ b/src/contest.c
@@ -42,6 +42,9 @@
 #include "constants/moves.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
+#ifdef PLATFORM_PC
+#include "../platform/pc/assets.h"
+#endif
 
 // This file's functions.
 static void LoadContestPalettes(void);
@@ -684,7 +687,17 @@ static const struct SpriteTemplate sSpriteTemplate_JudgeSpeechBubble =
     .callback = SpriteCallbackDummy
 };
 
+#ifdef PLATFORM_PC
+static const u16 *LoadContestTextPal(void)
+{
+    static const u16 *sPal;
+    if (!sPal)
+        sPal = AssetsLoadPal("graphics/contest/text.pal", NULL);
+    return sPal;
+}
+#else
 static const u16 sText_Pal[] = INCBIN_U16("graphics/contest/text.gbapal");
+#endif
 
 #include "data/contest_text_tables.h"
 
@@ -1075,7 +1088,19 @@ static void LoadContestPalettes(void)
 {
     s32 i;
 
-    LoadPalette(sText_Pal, BG_PLTT_ID(15), sizeof(sText_Pal));
+    LoadPalette(
+#ifdef PLATFORM_PC
+                LoadContestTextPal(),
+#else
+                sText_Pal,
+#endif
+                BG_PLTT_ID(15),
+#ifdef PLATFORM_PC
+                PLTT_SIZEOF(16)
+#else
+                sizeof(sText_Pal)
+#endif
+    );
     SetBackdropFromColor(RGB_BLACK);
     for (i = 10; i < 14; i++)
         LoadPalette(&gPlttBufferUnfaded[BG_PLTT_ID(15) + 1], BG_PLTT_ID(15) + i, PLTT_SIZEOF(1));


### PR DESCRIPTION
## Summary
- Load contest text palette from external PAL file when building for PC
- Load berry tag screen font palette from external PAL file on PC
- Document palette runtime loading in AGENTS_LOG

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_6897885d0ae88324a67dc1840c72ecb8