### PR TITLE
Load Pokeblock menu assets from external files on PC

### DIFF
--- a/AGENTS_LOG.txt
+++ b/AGENTS_LOG.txt
@@ -63,3 +63,4 @@
 - Removed duplicate sprite sheet and palette definitions in pokenav_menu_handler_gfx.c to finalize PokéNav main menu runtime loading.
 - Converted PokéNav ribbon list and ribbon summary assets to load graphics, tilemaps, and palettes from external files at runtime on PC builds, eliminating INCBIN data and enabling dynamic ribbon icons.
 - Converted Contest text palette and Berry Tag screen font palette to load from external .pal files at runtime on PC builds, removing corresponding INCBIN data.
+- Converted Pokéblock use screen to runtime asset loading for PC builds, decoding mon frame, graph, up/down arrows, condition icons, and nature window data from external PNG and PAL files and excluding related INCBIN assets.

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -4820,10 +4820,12 @@ extern const u32 gEnemyMonShadow_Gfx[];
 
 extern const u32 gBattleAnimFogTilemap[];
 
+#ifndef PLATFORM_PC
 extern const u32 gUsePokeblockGraph_Gfx[];
 extern const u32 gUsePokeblockGraph_Tilemap[];
 extern const u16 gUsePokeblockGraph_Pal[];
 extern const u16 gUsePokeblockNatureWin_Pal[];
+#endif
 
 // Berry blender
 extern const u8 gBerryBlenderPlayerArrow_Gfx[];
@@ -4996,7 +4998,9 @@ extern const u32 gEasyChatButtonWindow_Gfx[];
 extern const u16 gEasyChatButtonWindow_Pal[];
 
 // Use Pokeblock
+#ifndef PLATFORM_PC
 extern const u32 gUsePokeblockCondition_Gfx[];
+#endif
 
 // Union Room Chat
 extern const u16 gUnionRoomChat_Background_Pal[];
@@ -5012,10 +5016,10 @@ extern const u32 gUnionRoomChat_RButtonLabels[];
 #ifndef PLATFORM_PC
 extern const u8 gPokenavConditionCancel_Gfx[];
 extern const u16 gPokenavConditionCancel_Pal[];
-#endif
 extern const u8 gUsePokeblockUpDown_Gfx[];
 extern const u16 gUsePokeblockUpDown_Pal[];
 extern const u16 gUsePokeblockCondition_Pal[];
+#endif
 
 // Berry Crush
 extern const u32 gBerryCrush_Crusher_Gfx[];

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1354,6 +1354,7 @@ const u32 gWallClock_Gfx[]          = INCBIN_U32("graphics/wallclock/clock.4bpp.
 const u32 gWallClockStart_Tilemap[] = INCBIN_U32("graphics/wallclock/clock_start.bin.lz");
 const u32 gWallClockView_Tilemap[]  = INCBIN_U32("graphics/wallclock/clock_view.bin.lz");
 
+#ifndef PLATFORM_PC
 const u16 gUsePokeblockCondition_Pal[] = INCBIN_U16("graphics/pokeblock/use_screen/condition.gbapal");
 const u32 gUsePokeblockCondition_Gfx[] = INCBIN_U32("graphics/pokeblock/use_screen/condition.4bpp.lz");
 
@@ -1365,6 +1366,7 @@ const u32 gUsePokeblockGraph_Gfx[] = INCBIN_U32("graphics/pokeblock/use_screen/g
 
 const u32 gUsePokeblockGraph_Tilemap[] = INCBIN_U32("graphics/pokeblock/use_screen/graph.bin.lz");
 const u16 gUsePokeblockNatureWin_Pal[] = INCBIN_U16("graphics/pokeblock/use_screen/nature.gbapal");
+#endif
 
 #include "data/graphics/slot_machine.h"
 


### PR DESCRIPTION
## Summary
- Load Pokéblock use screen graphics, tilemaps, and palettes from PNG/JASC PAL files when building for PC
- Skip Pokéblock INCBIN data in graphics.c and headers for PC builds

## Testing
- `cc -Iinclude -DPLATFORM_PC -c src/main.c -o /tmp/main.o`
- `make PLATFORM=pc`
- `cc $(find build/pc -name '*.o') $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -o pokeemerald.exe`


------
https://chatgpt.com/codex/tasks/task_e_689792f7b4e0832489dcf9f2a399b83b